### PR TITLE
Removed npm ci

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -30,5 +30,4 @@ jobs:
       - name: Publish pkg to npm with provenance
         working-directory: pkg
         run: |
-          npm ci
           npm publish --provenance


### PR DESCRIPTION
The action was failing because of a missing package-lock.json which we dont have, since we dont have any dependencies, so we don't need to run `npm ci`