### PR TITLE
Fixing build without default features.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ jobs:
           rustup target add x86_64-unknown-linux-gnu
       - name: Build native crates
         run: cargo build --workspace --verbose
+      - name: Build without default features
+        run: cargo build --workspace --no-default-features --verbose
       - name: Build wasm target
         run: cargo build --workspace --target wasm32-unknown-unknown --verbose
 

--- a/src/comparator.rs
+++ b/src/comparator.rs
@@ -4,7 +4,6 @@
 //! in version constraints, such as =, !=, <, <=, >, >=, and *.
 
 use serde::{Deserialize, Serialize};
-use tsify::Tsify;
 use std::fmt;
 
 /// Comparator for version constraints.
@@ -12,7 +11,8 @@ use std::fmt;
 /// This enum represents the different types of comparators that can be used
 /// in version constraints. Each comparator defines how a version is compared
 /// to the constraint version.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Tsify)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 pub enum Comparator {
     /// Equal (=) - The version must be exactly equal to the constraint version.
     Equal,

--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -10,7 +10,6 @@
 use crate::{Comparator, VersError};
 use percent_encoding::percent_decode_str;
 use serde::{Deserialize, Serialize};
-use tsify::Tsify;
 use std::fmt::{Debug, Display};
 use std::str::FromStr;
 
@@ -32,7 +31,8 @@ impl<T> VersionType for T where T: FromStr + Default + Ord + Clone + Display + D
 /// - `<2.0.0` (less than)
 /// - `!=1.2.3` (not equal)
 /// - `*` (any version)
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Tsify)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 pub struct VersionConstraint<V: VersionType> {
     /// The comparator for this constraint
     pub comparator: Comparator,

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,19 +4,18 @@
 //! The main error type is `VersError`, which represents all possible
 //! errors that can occur when working with version range specifiers.
 
-#[cfg(feature = "wasm")]
-use js_sys::Error as JsError;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tsify::Tsify;
+
 #[cfg(feature = "wasm")]
-use wasm_bindgen::JsValue;
+use {js_sys::Error as JsError, tsify::Tsify, wasm_bindgen::JsValue};
 
 /// Errors that can occur when working with version range specifiers.
 ///
 /// This enum represents all the possible errors that can occur when parsing,
 /// validating, or using version range specifiers.
-#[derive(Error, Debug, PartialEq, Eq, Serialize, Deserialize, Tsify)]
+#[derive(Error, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
 pub enum VersError {
     #[error("Invalid URI scheme, expected 'vers'")]
     InvalidScheme,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ use wasm_bindgen::prelude::*;
 /// assert_eq!(range.versioning_scheme(), "npm");
 /// assert_eq!(range.constraints().len(), 2);
 /// ```
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub fn parse(s: &str) -> Result<DynamicVersionRange, VersError> {
     s.parse()
 }

--- a/src/range/dynamic.rs
+++ b/src/range/dynamic.rs
@@ -2,11 +2,10 @@ use crate::constraint::VersionType;
 use crate::range::VersionRange;
 use crate::schemes::semver::SemVer;
 use crate::{GenericVersionRange, VersError, VersionConstraint};
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
-use serde::{Deserialize, Serialize};
-use tsify::Tsify;
 
 /// A dynamic version range that automatically detects the versioning scheme.
 ///
@@ -31,8 +30,9 @@ use tsify::Tsify;
 /// assert!(npm_range.contains("1.5.0").unwrap());
 /// assert!(!npm_range.contains("2.0.0").unwrap());
 /// ```
-#[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
+#[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum DynamicVersionRange {
     /// SemVer-based range (for "semver" and "npm" schemes)
     SemVer(GenericVersionRange<SemVer>),

--- a/src/range/generic.rs
+++ b/src/range/generic.rs
@@ -31,7 +31,6 @@ use std::collections::LinkedList;
 use std::fmt;
 use std::fmt::Display;
 use std::str::FromStr;
-use tsify::Tsify;
 
 /// A version range specifier.
 ///
@@ -44,7 +43,8 @@ use tsify::Tsify;
 /// - `vers:npm/1.2.3` (a single version)
 /// - `vers:npm/>=1.0.0|<2.0.0` (a range of versions)
 /// - `vers:pypi/*` (any version)
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Tsify)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 pub struct GenericVersionRange<V: VersionType> {
     /// The versioning scheme (e.g., "npm", "pypi", "maven", "deb")
     pub versioning_scheme: String,

--- a/src/schemes/semver.rs
+++ b/src/schemes/semver.rs
@@ -2,13 +2,13 @@ use crate::VersError;
 use derive_more::Display;
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use tsify::Tsify;
 use std::cmp::Ordering;
 use std::str::FromStr;
 
 pub static SEMVER_SCHEME: &str = "semver/npm";
 
-#[derive(Display, Clone, Debug, PartialEq, Eq, PartialOrd, Serialize, Deserialize, Tsify)]
+#[derive(Display, Clone, Debug, PartialEq, Eq, PartialOrd, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 pub struct SemVer(Version);
 
 impl Default for SemVer {


### PR DESCRIPTION
The tsify and wasm_bindgen dependencies are (correctly) marked as optional, because they are only required by the "wasm" feature. However, they are unconditionally used in various places. Since the "wasm" feature flag is enabled by default, this only becomes relevant if default features are disabled.

This PR adds a verification test for the build without default features and guards the usage of tsify and wasm_bindgen behind a feature flag.