### PR TITLE
fix: added equal(=) branch to if-else clause

### DIFF
--- a/src/constraint.rs
+++ b/src/constraint.rs
@@ -185,7 +185,10 @@ impl<V: VersionType> VersionConstraint<V> {
             (Comparator::GreaterThan, stripped)
         } else if let Some(stripped) = constraint_str.strip_prefix('<') {
             (Comparator::LessThan, stripped)
+        } else if let Some(stripped) = constraint_str.strip_prefix('=') {
+            (Comparator::Equal, stripped)
         } else {
+            // without any prefix we assume Equal
             (Comparator::Equal, constraint_str)
         };
 


### PR DESCRIPTION
I added a new branch to the if-clause to check for the equals(=) prefix