### PR TITLE
Feature: fixes issue #20 by adding support for cargo

### DIFF
--- a/src/range/dynamic.rs
+++ b/src/range/dynamic.rs
@@ -1,7 +1,6 @@
 use crate::constraint::NativeVersionConverter;
 use crate::range::VersionRange;
-use crate::schemes::deb::DebVersion;
-use crate::schemes::semver::SemVer;
+use crate::schemes::{cargo::CargoVersion, deb::DebVersion, semver::SemVer};
 use crate::{VersError, VersVersionRange, VersionConstraint};
 use std::fmt;
 use std::fmt::{Display, Formatter};
@@ -18,6 +17,9 @@ enum DynamicVersionRangeInner {
     /// Debian dpkg-style versioning ("deb" scheme)
     #[serde(rename = "deb")]
     Deb(VersVersionRange<DebVersion>),
+    /// Cargo-based range ("cargo" scheme)
+    #[serde(rename = "cargo")]
+    Cargo(VersVersionRange<CargoVersion>),
 }
 
 /// A dynamic version range that automatically detects the versioning scheme.
@@ -74,6 +76,7 @@ macro_rules! dispatch_inner {
         match $inner {
             DynamicVersionRangeInner::SemVer($range) => $expr,
             DynamicVersionRangeInner::Deb($range) => $expr,
+            DynamicVersionRangeInner::Cargo($range) => $expr,
         }
     };
 }
@@ -110,6 +113,9 @@ impl DynamicVersionRange {
                 DynamicVersionRangeInner::SemVer(SemVer::from_native_string(scheme, raw)?)
             }
             "deb" => DynamicVersionRangeInner::Deb(DebVersion::from_native_string(scheme, raw)?),
+            "cargo" => {
+                DynamicVersionRangeInner::Cargo(CargoVersion::from_native_string(scheme, raw)?)
+            }
             _ => return Err(VersError::UnsupportedVersioningScheme(scheme.to_string())),
         };
 
@@ -206,6 +212,9 @@ impl VersionRange<String> for DynamicVersionRange {
             DynamicVersionRangeInner::Deb(range) => {
                 range.contains(version_str.parse::<DebVersion>()?)
             }
+            DynamicVersionRangeInner::Cargo(range) => {
+                range.contains(version_str.parse::<CargoVersion>()?)
+            }
         }
     }
 
@@ -269,6 +278,7 @@ impl FromStr for DynamicVersionRange {
         let inner = match versioning_scheme.as_str() {
             "semver" | "npm" => DynamicVersionRangeInner::SemVer(s.parse()?),
             "deb" => DynamicVersionRangeInner::Deb(s.parse()?),
+            "cargo" => DynamicVersionRangeInner::Cargo(s.parse()?),
             _ => return Err(VersError::UnsupportedVersioningScheme(versioning_scheme)),
         };
 
@@ -521,5 +531,99 @@ mod tests {
     fn test_parse_native_roundtrip() {
         let range = DynamicVersionRange::parse_native("npm", ">=1.0.0|<2.0.0").unwrap();
         assert_eq!(range.to_string(), "vers:npm/>=1.0.0|<2.0.0");
+    }
+
+    #[test]
+    fn test_dynamic_parse_cargo() {
+        let range: DynamicVersionRange = "vers:cargo/^1.2.3".parse().unwrap();
+        assert_eq!(range.versioning_scheme(), "cargo");
+        assert_eq!(range.constraints().len(), 2);
+    }
+
+    #[test]
+    fn test_parse_native_cargo() {
+        let range = DynamicVersionRange::parse_native("cargo", "~1.2.3").unwrap();
+        assert_eq!(range.versioning_scheme(), "cargo");
+        assert_eq!(range.constraints().len(), 2);
+    }
+
+    #[test]
+    fn test_cargo_dynamic_contains() {
+        let range: DynamicVersionRange = "vers:cargo/^1.2.3".parse().unwrap();
+        assert!(range.contains("1.2.3".to_string()).unwrap());
+        assert!(range.contains("1.5.0".to_string()).unwrap());
+        assert!(!range.contains("2.0.0".to_string()).unwrap());
+    }
+
+    #[test]
+    fn test_cargo_dynamic_wildcard() {
+        let range: DynamicVersionRange = "vers:cargo/1.*".parse().unwrap();
+        assert!(range.contains("1.2.3".to_string()).unwrap());
+        assert!(!range.contains("2.0.0".to_string()).unwrap());
+    }
+
+    #[test]
+    fn test_cargo_explicit_operators_with_partial_versions() {
+        let range: DynamicVersionRange = "vers:cargo/>=1.2,<1.5".parse().unwrap();
+        assert_eq!(range.versioning_scheme(), "cargo");
+        assert_eq!(range.constraints().len(), 2);
+        assert_eq!(
+            range.constraints()[0].comparator,
+            Comparator::GreaterThanOrEqual
+        );
+        assert_eq!(range.constraints()[0].version.to_string(), "1.2.0");
+        assert_eq!(range.constraints()[1].comparator, Comparator::LessThan);
+        assert_eq!(range.constraints()[1].version.to_string(), "1.5.0");
+
+        let single_bound: DynamicVersionRange = "vers:cargo/<=2".parse().unwrap();
+        assert_eq!(single_bound.constraints().len(), 1);
+        assert_eq!(
+            single_bound.constraints()[0].comparator,
+            Comparator::LessThanOrEqual
+        );
+        assert_eq!(single_bound.constraints()[0].version.to_string(), "2.0.0");
+    }
+
+    #[test]
+    fn test_cargo_zero_major_caret_expansions() {
+        // ^0.2.3 expands to >=0.2.3, <0.3.0
+        let range: DynamicVersionRange = "vers:cargo/^0.2.3".parse().unwrap();
+        assert_eq!(range.constraints().len(), 2);
+        assert_eq!(range.constraints()[1].version.to_string(), "0.3.0");
+
+        // ^0.0.3 expands to >=0.0.3, <0.0.4
+        let range_zero: DynamicVersionRange = "vers:cargo/^0.0.3".parse().unwrap();
+        assert_eq!(range_zero.constraints().len(), 2);
+        assert_eq!(range_zero.constraints()[1].version.to_string(), "0.0.4");
+    }
+
+    #[test]
+    fn test_cargo_partial_wildcards() {
+        let range: DynamicVersionRange = "vers:cargo/1.2.*".parse().unwrap();
+        assert_eq!(range.constraints().len(), 2);
+        assert_eq!(
+            range.constraints()[0].comparator,
+            Comparator::GreaterThanOrEqual
+        );
+        assert_eq!(range.constraints()[0].version.to_string(), "1.2.0");
+        assert_eq!(range.constraints()[1].comparator, Comparator::LessThan);
+        assert_eq!(range.constraints()[1].version.to_string(), "1.3.0");
+    }
+
+    #[test]
+    fn test_cargo_pipe_disjunctions() {
+        let range: DynamicVersionRange = "vers:cargo/^1.0.0 | ~2.1.0".parse().unwrap();
+        assert_eq!(range.constraints().len(), 4);
+        assert!(range.contains("1.5.0".to_string()).unwrap());
+        assert!(range.contains("2.1.4".to_string()).unwrap());
+        assert!(!range.contains("2.2.0".to_string()).unwrap());
+    }
+
+    #[test]
+    fn test_cargo_prerelease_versions() {
+        let range: DynamicVersionRange = "vers:cargo/^1.2.3-alpha.1".parse().unwrap();
+        assert!(range.contains("1.2.3-alpha.2".to_string()).unwrap());
+        assert!(range.contains("1.2.3".to_string()).unwrap());
+        assert!(!range.contains("2.0.0".to_string()).unwrap());
     }
 }

--- a/src/schemes/cargo.rs
+++ b/src/schemes/cargo.rs
@@ -1,0 +1,299 @@
+//! Version constraint type for the Cargo versioning scheme.
+//!
+//! This module contains the `CargoVersion` struct and its implementation of the
+//! `NativeVersionConverter` trait, supporting Cargo dependency specification rules
+//! (caret, tilde, wildcards, exact, and comparative ranges).
+
+use crate::VersError;
+use crate::VersionConstraint;
+use crate::comparator::Comparator;
+use crate::constraint::NativeVersionConverter;
+use derive_more::Display;
+use semver::Version;
+use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
+use std::str::FromStr;
+
+pub static CARGO_SCHEME: &str = "cargo";
+
+#[derive(Display, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+pub struct CargoVersion(Version);
+
+impl Default for CargoVersion {
+    fn default() -> Self {
+        CargoVersion(Version::new(0, 0, 0))
+    }
+}
+
+impl NativeVersionConverter for CargoVersion {
+    const SCHEME_NAME: &'static str = "cargo";
+
+    /// Parse a full native range string into one or more standard `VersionConstraint`s.
+    ///
+    /// Cargo native constraints can use commas (`,`) for conjunction within a segment
+    /// and pipes (`|`) for disjunction between segments. Because a single Cargo spec
+    /// like `^1.2.3` or `1.2.*` or `~1.2` can expand into multiple constraints (e.g. `>=1.2.3, <2.0.0`),
+    /// we override `from_native` to correctly flatten all segments and comma-separated clauses.
+    fn from_native(raw: &str) -> Result<Vec<VersionConstraint<Self>>, VersError> {
+        let raw = raw.trim();
+        if raw.is_empty() {
+            return Err(VersError::EmptyConstraints);
+        }
+
+        let segments: Vec<&str> = raw
+            .trim_matches('|')
+            .split('|')
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        if segments.is_empty() {
+            return Err(VersError::EmptyConstraints);
+        }
+
+        let mut all_constraints = Vec::new();
+        for segment in segments {
+            if segment.contains(',') {
+                for part in segment.split(',') {
+                    let part = part.trim();
+                    if !part.is_empty() {
+                        all_constraints.extend(Self::parse_single_cargo_spec(part)?);
+                    }
+                }
+            } else {
+                all_constraints.extend(Self::parse_single_cargo_spec(segment)?);
+            }
+        }
+
+        if all_constraints.is_empty() {
+            return Err(VersError::EmptyConstraints);
+        }
+
+        Ok(all_constraints)
+    }
+
+    /// Parse a single native constraint string into a single `VersionConstraint`.
+    /// If the single constraint expands into multiple bounds (like a caret or tilde range),
+    /// we return an error or handle it appropriately for single-constraint contexts.
+    fn from_native_constraint(raw: &str) -> Result<VersionConstraint<Self>, VersError> {
+        let constraints = Self::parse_single_cargo_spec(raw)?;
+        if constraints.len() == 1 {
+            Ok(constraints.into_iter().next().unwrap())
+        } else {
+            Err(VersError::InvalidConstraint(format!(
+                "Constraint '{}' expands to multiple bounds; please use from_native instead",
+                raw
+            )))
+        }
+    }
+}
+
+impl CargoVersion {
+    fn parse_single_cargo_spec(raw: &str) -> Result<Vec<VersionConstraint<Self>>, VersError> {
+        let raw = raw.trim();
+
+        if raw.ends_with(".*") || raw == "*" {
+            return expand_wildcard(raw);
+        }
+
+        if let Some(stripped) = raw.strip_prefix('~') {
+            return expand_tilde(stripped.trim());
+        }
+
+        let (is_explicit_caret, version_part) = if let Some(stripped) = raw.strip_prefix('^') {
+            (true, stripped.trim())
+        } else {
+            (false, raw)
+        };
+
+        if let Some(stripped) = version_part.strip_prefix(">=") {
+            let v = parse_version_loose(stripped, raw)?;
+            return Ok(vec![VersionConstraint::new(
+                Comparator::GreaterThanOrEqual,
+                CargoVersion(v),
+            )]);
+        }
+        if let Some(stripped) = version_part.strip_prefix("<=") {
+            let v = parse_version_loose(stripped, raw)?;
+            return Ok(vec![VersionConstraint::new(
+                Comparator::LessThanOrEqual,
+                CargoVersion(v),
+            )]);
+        }
+        if let Some(stripped) = version_part.strip_prefix('>') {
+            let v = parse_version_loose(stripped, raw)?;
+            return Ok(vec![VersionConstraint::new(
+                Comparator::GreaterThan,
+                CargoVersion(v),
+            )]);
+        }
+        if let Some(stripped) = version_part.strip_prefix('<') {
+            let v = parse_version_loose(stripped, raw)?;
+            return Ok(vec![VersionConstraint::new(
+                Comparator::LessThan,
+                CargoVersion(v),
+            )]);
+        }
+        if let Some(stripped) = version_part.strip_prefix('=') {
+            let v = parse_version_loose(stripped, raw)?;
+            return Ok(vec![VersionConstraint::new(
+                Comparator::Equal,
+                CargoVersion(v),
+            )]);
+        }
+
+        expand_caret_or_default(version_part, is_explicit_caret)
+    }
+}
+
+fn parse_version_loose(s: &str, original: &str) -> Result<Version, VersError> {
+    let s = s.trim();
+    let core_part = s.split(['-', '+']).next().unwrap_or(s);
+    let dot_count = core_part.matches('.').count();
+
+    let normalized = if dot_count == 1 {
+        format!("{}.0", s)
+    } else if dot_count == 0 {
+        format!("{}.0.0", s)
+    } else {
+        s.to_string()
+    };
+    Version::parse(&normalized).map_err(|e| {
+        VersError::InvalidVersionFormat(CARGO_SCHEME, original.to_string(), e.to_string())
+    })
+}
+
+fn expand_wildcard(raw: &str) -> Result<Vec<VersionConstraint<CargoVersion>>, VersError> {
+    if raw == "*" {
+        return Ok(vec![VersionConstraint::new(
+            Comparator::Any,
+            CargoVersion::default(),
+        )]);
+    }
+    let base = &raw[..raw.len() - 2];
+    let parts: Vec<&str> = base.split('.').collect();
+    match parts.len() {
+        1 => {
+            let major = parts[0]
+                .parse::<u64>()
+                .map_err(|_| VersError::InvalidConstraint(raw.to_string()))?;
+            Ok(vec![
+                VersionConstraint::new(
+                    Comparator::GreaterThanOrEqual,
+                    CargoVersion(Version::new(major, 0, 0)),
+                ),
+                VersionConstraint::new(
+                    Comparator::LessThan,
+                    CargoVersion(Version::new(major + 1, 0, 0)),
+                ),
+            ])
+        }
+        2 => {
+            let major = parts[0]
+                .parse::<u64>()
+                .map_err(|_| VersError::InvalidConstraint(raw.to_string()))?;
+            let minor = parts[1]
+                .parse::<u64>()
+                .map_err(|_| VersError::InvalidConstraint(raw.to_string()))?;
+            Ok(vec![
+                VersionConstraint::new(
+                    Comparator::GreaterThanOrEqual,
+                    CargoVersion(Version::new(major, minor, 0)),
+                ),
+                VersionConstraint::new(
+                    Comparator::LessThan,
+                    CargoVersion(Version::new(major, minor + 1, 0)),
+                ),
+            ])
+        }
+        _ => Err(VersError::InvalidConstraint(raw.to_string())),
+    }
+}
+
+fn expand_tilde(s: &str) -> Result<Vec<VersionConstraint<CargoVersion>>, VersError> {
+    let core_part = s.split(['-', '+']).next().unwrap_or(s);
+    let dots = core_part.matches('.').count();
+    let v = parse_version_loose(s, s)?;
+    if dots == 2 || dots == 1 {
+        Ok(vec![
+            VersionConstraint::new(Comparator::GreaterThanOrEqual, CargoVersion(v.clone())),
+            VersionConstraint::new(
+                Comparator::LessThan,
+                CargoVersion(Version::new(v.major, v.minor + 1, 0)),
+            ),
+        ])
+    } else {
+        Ok(vec![
+            VersionConstraint::new(Comparator::GreaterThanOrEqual, CargoVersion(v.clone())),
+            VersionConstraint::new(
+                Comparator::LessThan,
+                CargoVersion(Version::new(v.major + 1, 0, 0)),
+            ),
+        ])
+    }
+}
+
+fn expand_caret_or_default(
+    s: &str,
+    _explicit: bool,
+) -> Result<Vec<VersionConstraint<CargoVersion>>, VersError> {
+    let core_part = s.split(['-', '+']).next().unwrap_or(s);
+    let dots = core_part.matches('.').count();
+    let v = parse_version_loose(s, s)?;
+
+    if dots == 2 {
+        let upper = if v.major > 0 {
+            Version::new(v.major + 1, 0, 0)
+        } else if v.minor > 0 {
+            Version::new(0, v.minor + 1, 0)
+        } else {
+            Version::new(0, 0, v.patch + 1)
+        };
+        Ok(vec![
+            VersionConstraint::new(Comparator::GreaterThanOrEqual, CargoVersion(v)),
+            VersionConstraint::new(Comparator::LessThan, CargoVersion(upper)),
+        ])
+    } else if dots == 1 {
+        let upper = if v.major > 0 {
+            Version::new(v.major + 1, 0, 0)
+        } else {
+            Version::new(0, v.minor + 1, 0)
+        };
+        Ok(vec![
+            VersionConstraint::new(Comparator::GreaterThanOrEqual, CargoVersion(v)),
+            VersionConstraint::new(Comparator::LessThan, CargoVersion(upper)),
+        ])
+    } else {
+        let upper = v.major + 1;
+        Ok(vec![
+            VersionConstraint::new(Comparator::GreaterThanOrEqual, CargoVersion(v)),
+            VersionConstraint::new(
+                Comparator::LessThan,
+                CargoVersion(Version::new(upper, 0, 0)),
+            ),
+        ])
+    }
+}
+
+impl PartialOrd for CargoVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for CargoVersion {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl FromStr for CargoVersion {
+    type Err = VersError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim();
+        let v = parse_version_loose(s, s)?;
+        Ok(CargoVersion(v))
+    }
+}

--- a/src/schemes/mod.rs
+++ b/src/schemes/mod.rs
@@ -1,2 +1,3 @@
+pub mod cargo;
 pub mod deb;
 pub mod semver;


### PR DESCRIPTION
Covers every core component of Cargo's dependency specification syntax, hopefully =)
- Standard caret requirements (^1.2.3)
- Zero-major and zero-minor caret expansions (^0.2.3, ^0.0.3)
- Tilde requirements (~1.2.3)
- Wildcards (*, 1.*, 1.2.*)
- Explicit comparison operators with partial version padding (>=1.2, <=2)
- Multiple comma-separated constraints per segment (>=1.2,<1.5)
- Pipe-delimited disjunctions (|)
- Pre-release and metadata version tags (-alpha.1)
Addresses https://github.com/csaf-rs/vers-rs/issues/20