### PR TITLE
Use shared composite actions for Rust CI format and lint checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,7 @@ jobs:
       - name: Run shared format and clippy checks
         uses: csaf-rs/shared-workflows/.github/actions/rust-checks@main
         with:
-          run-format: "true"
-          run-clippy: "true"
-          clippy-args: "--locked --all-targets --workspace"
+          clippy-extra-args: "--workspace"
       - name: Prepare targets
         run: |
           rustup target add wasm32-unknown-unknown

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,18 +10,16 @@ jobs:
       - uses: actions/checkout@v7
       - name: Update rustup
         run: rustup update stable --no-self-update
-      - name: Format check
-        run: |
-          rustup component add rustfmt
-          cargo fmt --all -- --check -l
+      - name: Run shared format and clippy checks
+        uses: csaf-rs/shared-workflows/.github/actions/rust-checks@main
+        with:
+          run-format: "true"
+          run-clippy: "true"
+          clippy-args: "--locked --all-targets --workspace"
       - name: Prepare targets
         run: |
           rustup target add wasm32-unknown-unknown
           rustup target add x86_64-unknown-linux-gnu
-      - name: Clippy check
-        run: |
-          rustup component add clippy
-          cargo clippy --locked --all-targets --workspace -- -D warnings
       - name: Run tests
         run: cargo test --locked --all-targets --workspace --verbose
       - name: Build native crates


### PR DESCRIPTION
This PR addresses csaf-rs/csaf#787.

**Note:** Before merging this PR, please make sure that the dependent [shared-workflows PR](https://github.com/csaf-rs/shared-workflows/pull/1) has been merged first, since this workflow uses the composite action introduced there.

This PR updates the `vers-rs` build workflow to use the shared `rust-checks` composite action from `csaf-rs/shared-workflows` for the existing formatting and Clippy checks.

The existing repository-specific checks and workflow logic remains in `vers-rs`. The existing Clippy arguments are preserved. As formatting and Clippy are now executed together by the shared action, the Clippy check runs before the target preparation step.

Implementation details and validation of the shared action can be found in the dependent [shared-workflows PR](https://github.com/csaf-rs/shared-workflows/pull/1).