### PR TITLE
Bug: fixes bug #31 by using String instead of &'static str in VersErr…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,12 +133,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,15 +196,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -308,6 +302,7 @@ dependencies = [
  "semver",
  "serde",
  "serde-wasm-bindgen",
+ "serde_json",
  "thiserror",
  "tsify",
  "wasm-bindgen",
@@ -381,3 +376,9 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ js-sys = { version = "*", optional = true }
 tsify = { version = "*", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = { version = "0.5", optional = true }
+serde_json = "1.0.151"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,6 @@ js-sys = { version = "*", optional = true }
 tsify = { version = "*", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = { version = "0.5", optional = true }
+
+[dev-dependencies]
 serde_json = "1.0.151"

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,7 +42,7 @@ pub enum VersError {
     UnsupportedVersioningScheme(String),
 
     #[error("Invalid version format for scheme {0}: {1}, error was: {2}")]
-    InvalidVersionFormat(&'static str, String, String),
+    InvalidVersionFormat(String, String, String),
 }
 
 /// Convert VersError into a JS exception value when targeting wasm.
@@ -50,5 +50,30 @@ pub enum VersError {
 impl From<VersError> for JsValue {
     fn from(e: VersError) -> JsValue {
         JsValue::from(JsError::new(&e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vers_error_round_trips_through_json() {
+        let original = VersError::InvalidVersionFormat(
+            "deb".to_string(),
+            "<<1.0.0!".to_string(),
+            "unexpected character '!'".to_string(),
+        );
+
+        // Serialisation works fine, as Serialize has no lifetime constraints
+        let json: String = serde_json::to_string(&original).unwrap();
+        assert_eq!(
+            json,
+            r#"{"InvalidVersionFormat":["deb","<<1.0.0!","unexpected character '!'"]}"#
+        );
+
+        // Deserialisation from a runtime String does not compile
+        let roundtripped: VersError = serde_json::from_str(&json).unwrap();
+        assert_eq!(roundtripped, original);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -72,7 +72,7 @@ mod tests {
             r#"{"InvalidVersionFormat":["deb","<<1.0.0!","unexpected character '!'"]}"#
         );
 
-        // Deserialisation from a runtime String does not compile
+        // Deserialisation from a runtime String successfully compiles and roundtrips
         let roundtripped: VersError = serde_json::from_str(&json).unwrap();
         assert_eq!(roundtripped, original);
     }

--- a/src/schemes/deb.rs
+++ b/src/schemes/deb.rs
@@ -7,12 +7,12 @@ use std::cmp::Ordering;
 use std::str::FromStr;
 
 /// Scheme identifier string for Debian versions
-pub static DEB_SCHEME: &str = "deb";
+pub const DEB_SCHEME: &str = "deb";
 
 /// Macro to create InvalidVersionFormat errors for Debian versions
 macro_rules! deb_format_error {
     ($s:expr, $msg:expr) => {
-        VersError::InvalidVersionFormat(DEB_SCHEME.into(), $s.to_string(), $msg.into())
+        VersError::InvalidVersionFormat(DEB_SCHEME.to_string(), $s.to_string(), $msg.into())
     };
 }
 

--- a/src/schemes/deb.rs
+++ b/src/schemes/deb.rs
@@ -12,7 +12,7 @@ pub static DEB_SCHEME: &str = "deb";
 /// Macro to create InvalidVersionFormat errors for Debian versions
 macro_rules! deb_format_error {
     ($s:expr, $msg:expr) => {
-        VersError::InvalidVersionFormat(DEB_SCHEME, $s.to_string(), $msg.into())
+        VersError::InvalidVersionFormat(DEB_SCHEME.into(), $s.to_string(), $msg.into())
     };
 }
 

--- a/src/schemes/semver.rs
+++ b/src/schemes/semver.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::str::FromStr;
 
-pub static SEMVER_SCHEME: &str = "semver/npm";
+pub const SEMVER_SCHEME: &str = "semver/npm";
 
 #[derive(Display, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
@@ -66,7 +66,7 @@ impl FromStr for SemVer {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(SemVer(Version::parse(s).map_err(|e| {
-            VersError::InvalidVersionFormat(SEMVER_SCHEME.into(), s.to_string(), e.to_string())
+            VersError::InvalidVersionFormat(SEMVER_SCHEME.to_string(), s.to_string(), e.to_string())
         })?))
     }
 }

--- a/src/schemes/semver.rs
+++ b/src/schemes/semver.rs
@@ -66,7 +66,7 @@ impl FromStr for SemVer {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(SemVer(Version::parse(s).map_err(|e| {
-            VersError::InvalidVersionFormat(SEMVER_SCHEME, s.to_string(), e.to_string())
+            VersError::InvalidVersionFormat(SEMVER_SCHEME.into(), s.to_string(), e.to_string())
         })?))
     }
 }


### PR DESCRIPTION
…or::InvalidVersionFormat to resolve serde deserialization lifetime constraints

This PR fixes a serialization/deserialization lifetime compilation bug with VersError when targeting serde with runtime strings.

Key Fixes

- VersError::InvalidVersionFormat Refactor: Changed the first field (&'static str) to an owned String.
- Eliminates the 'static lifetime constraint on the derived Deserialize implementation, allowing VersError to cleanly round-trip and deserialize from runtime JSON sources (serde_json::from_str).
- Codebase Alignment: Updated construction sites of InvalidVersionFormat to supply owned strings.
- Testing: Added a comprehensive JSON round-trip test for VersError to prevent future lifetime regressions.
- 
Hopefully fixes issue #31 