### PR TITLE
Adapt composite action CI calls to the clippy --workspace default arg…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,6 @@ jobs:
         run: rustup update stable --no-self-update
       - name: Run shared format and clippy checks
         uses: csaf-rs/shared-workflows/.github/actions/rust-checks@main
-        with:
-          clippy-extra-args: "--workspace"
       - name: Prepare targets
         run: |
           rustup target add wasm32-unknown-unknown


### PR DESCRIPTION
This PR addresses https://github.com/csaf-rs/csaf/issues/787 and also resolves the reviewer [comment](https://github.com/csaf-rs/vers-rs/pull/49/files/cb41e739dce6de3beff60279717f4b53bedb348a#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721).

It adapts the current composite action calls in build.yml to the new `--workspace` default in the shared Clippy check.

This PR is part of the corresponding CI changes across the repositories. To complete the overall change, the following PR should **firstly** be merged:
- https://github.com/csaf-rs/shared-workflows/pull/2